### PR TITLE
Add pubip to piactl get command

### DIFF
--- a/cli/src/getcommand.cpp
+++ b/cli/src/getcommand.cpp
@@ -130,7 +130,7 @@ namespace
         {GetSetType::requestPortForward, {QStringLiteral("Whether a forwarded port will be requested on the next connection attempt"), {}}},
         {GetSetType::protocol, {QStringLiteral("VPN connection protocol"), DaemonSettings::choices_method()}},
         {GetSetType::vpnIp, {QStringLiteral("Current VPN IP address"), {}}},
-        {GetSetType::pubIp, {QStringLiteral("Current Public IP address"), {}}},
+        {GetSetType::pubIp, {QStringLiteral("Current public IP address"), {}}},
         {GetSetType::region, {QStringLiteral("Currently selected region (or \"auto\")"), {}}}
     };
 
@@ -347,6 +347,11 @@ namespace
         else if(_type  == GetSetType::vpnIp)
         {
             QObject::connect(&client.connection().state, &DaemonState::externalVpnIpChanged,
+                             this, func);
+        }
+        else if(_type  == GetSetType::pubIp)
+        {
+            QObject::connect(&client.connection().state, &DaemonState::externalIpChanged,
                              this, func);
         }
         else

--- a/cli/src/getcommand.cpp
+++ b/cli/src/getcommand.cpp
@@ -271,7 +271,7 @@ namespace
         else if(type == GetSetType::vpnIp)
         {
             const auto &ip = client.connection().state.externalVpnIp();
-            // If the address isn't unknown, print Unknown
+            // If the address isn't known, print Unknown
             if(ip.isEmpty())
                 return QStringLiteral("Unknown");
             return ip;
@@ -279,7 +279,7 @@ namespace
         else if(type == GetSetType::pubIp)
         {
             const auto &ip = client.connection().state.externalIp();
-            // If the address isn't unknown, print Unknown
+            // If the address isn't known, print Unknown
             if(ip.isEmpty())
                 return QStringLiteral("Unknown");
             return ip;

--- a/cli/src/getcommand.cpp
+++ b/cli/src/getcommand.cpp
@@ -36,6 +36,7 @@ namespace GetSetType
     const QString region{QStringLiteral("region")};
     const QString regions{QStringLiteral("regions")};
     const QString vpnIp{QStringLiteral("vpnip")};
+    const QString pubIp{QStringLiteral("pubip")};
     const QString daemonState{QStringLiteral("daemon-state")};
     const QString daemonSettings{QStringLiteral("daemon-settings")};
 }
@@ -129,6 +130,7 @@ namespace
         {GetSetType::requestPortForward, {QStringLiteral("Whether a forwarded port will be requested on the next connection attempt"), {}}},
         {GetSetType::protocol, {QStringLiteral("VPN connection protocol"), DaemonSettings::choices_method()}},
         {GetSetType::vpnIp, {QStringLiteral("Current VPN IP address"), {}}},
+        {GetSetType::pubIp, {QStringLiteral("Current Public IP address"), {}}},
         {GetSetType::region, {QStringLiteral("Currently selected region (or \"auto\")"), {}}}
     };
 
@@ -269,6 +271,14 @@ namespace
         else if(type == GetSetType::vpnIp)
         {
             const auto &ip = client.connection().state.externalVpnIp();
+            // If the address isn't unknown, print Unknown
+            if(ip.isEmpty())
+                return QStringLiteral("Unknown");
+            return ip;
+        }
+        else if(type == GetSetType::pubIp)
+        {
+            const auto &ip = client.connection().state.externalIp();
             // If the address isn't unknown, print Unknown
             if(ip.isEmpty())
                 return QStringLiteral("Unknown");

--- a/cli/src/getcommand.h
+++ b/cli/src/getcommand.h
@@ -29,7 +29,7 @@
 namespace GetSetType
 {
     extern const QString connectionState, debugLogging, portForward, requestPortForward, protocol,
-                         region, regions, vpnIp, daemonState, daemonSettings;
+                         region, regions, vpnIp, pubIp, daemonState, daemonSettings;
 }
 
 namespace GetSetValue


### PR DESCRIPTION
**Description**
This changes adds `pubip` to `piactl get` CLI tool. It fixes #14 

**Checklist**
- [x] I have described below how to test my code and included unit tests where possible.
- [x] I have cleaned up the code and made best efforts to match the surrounding coding style.
- [x] I certify that I have the right to submit this contribution under the GPLv3 and alter as outlined in the [Contributor License Agreement](https://github.com/pia-foss/desktop/blob/master/CLA.md).

**Testing Plan**
I have built this change from source and verified that it returns the Public IP Address as displayed in the GUI
