### PR TITLE
Add keywords in desktop entry for easier search.

### DIFF
--- a/extras/installer/linux/installfiles/piavpn.desktop
+++ b/extras/installer/linux/installfiles/piavpn.desktop
@@ -9,3 +9,4 @@ Terminal=false
 Categories=Network
 StartupWMClass={{BRAND_CODE}}-client
 MimeType=x-scheme-handler/{{BRAND_CODE}}vpn
+Keywords=VPN;PIA;


### PR DESCRIPTION
Keywords after the `Keywords` key can be used during search. For example, when a user searches VPN, apps that have "VPN" as keyword will show up as well.

*Example where I added the keywords manually*
![image](https://github.com/user-attachments/assets/103a4390-bc3c-46ef-980c-c53f7282be44)
