### PR TITLE
macOS: VPN hangs under load on any OSX 15+

### DIFF
--- a/daemon/res/pf/400.allowPIA.conf
+++ b/daemon/res/pf/400.allowPIA.conf
@@ -1,2 +1,5 @@
-# Allow traffic by privileged group (used by daemon)
-pass out proto { tcp, udp } group {{BRAND_CODE}}vpn flags any no state
+# Tunnel's own source address (filled at run-time; empty while disconnected)
+table <tunnelsrc> { }
+# Allow traffic by privileged group (used by daemon).  Excluding the tunnel
+# source keeps tunnel packets from reaching the group clause, which deadlocks the kernel.
+pass out proto { tcp, udp } from ! <tunnelsrc> group {{BRAND_CODE}}vpn flags any no state

--- a/kapps_net/src/mac/mac_firewall.cpp
+++ b/kapps_net/src/mac/mac_firewall.cpp
@@ -176,6 +176,10 @@ void MacFirewall::applyRules(const FirewallParams &params)
     }
 
     _pFilter->setFilterEnabled("400.allowPIA", params.allowPIA);
+    _pFilter->setAnchorTable("400.allowPIA", params.allowPIA, "tunnelsrc",
+        params.tunnelDeviceLocalAddress.empty()
+            ? std::vector<std::string>{}
+            : std::vector{params.tunnelDeviceLocalAddress});
     _pFilter->setFilterEnabled("500.blockDNS", dnsLeakProtection.macBlockDNS, { {"interface", params.tunnelDeviceName} });
     _pFilter->setAnchorTable("500.blockDNS", dnsLeakProtection.macBlockDNS, "localdns", dnsLeakProtection.localDnsServers);
     _pFilter->setAnchorTable("500.blockDNS", dnsLeakProtection.macBlockDNS, "tunneldns", dnsLeakProtection.tunnelDnsServers);


### PR DESCRIPTION
This PR refines `400.allowPIA.conf` so that it avoids a kernel deadlock bug present in OSX 15+. The bug and the fix only affect OSX.

## Reproduction

Connect the VPN and run a BitTorrent client over the tunnel with port forwarding on, sustaining roughly 700 new connections per minute through `utun`. Within about 15 to 45 minutes tunnel throughput stops dead and the whole machine wedges — unkillable processes, no networking, requiring a power cycle or ending in a `configd` watchdog panic. It reproduces on both WireGuard and OpenVPN, which share no code beyond the `utun` data path. Reproduced here twice, on macOS 15.7.3 and 15.7.9 (M3 Pro), with symbolicated stacks both times.

## The fix

This is the smallest, least disruptive fix I could find.

The conf change adds a table holding the tunnel's own source address and excludes it from the rule, so tunnel packets fail the source-address test before pf ever evaluates the group clause:

```diff
+# Tunnel's own source address (filled at run-time; empty while disconnected)
+table <tunnelsrc> { }
 # Allow traffic by privileged group (used by daemon)
-pass out proto { tcp, udp } group {{BRAND_CODE}}vpn flags any no state
+pass out proto { tcp, udp } from ! <tunnelsrc> group {{BRAND_CODE}}vpn flags any no state
```

The C++ change simply routes `params.tunnelDeviceLocalAddress` into that table, using the same `setAnchorTable()` mechanism four other anchors already use:

```diff
     _pFilter->setFilterEnabled("400.allowPIA", params.allowPIA);
+    _pFilter->setAnchorTable("400.allowPIA", params.allowPIA, "tunnelsrc",
+        params.tunnelDeviceLocalAddress.empty()
+            ? std::vector<std::string>{}
+            : std::vector{params.tunnelDeviceLocalAddress});
```

**The verdict for every packet is unchanged.** The ruleset is last-match-wins and no anchor in the path uses `quick` (only `000.allowLoopback` does, and `lo0` is `set skip`ped outright), so a tunnel packet previously matched `200.allowVPN` (pass) and then *also* `400.allowPIA` (pass). Removing the second match leaves the first standing. What goes away is only the side effect — the PCB lookup and the lock acquisition. The exemption the rule exists for is untouched: the daemon still escapes `100.blockAll` on the physical interface.

No sentinel value or special case is needed for the disconnected state. `PF_MISMATCHAW` negates to "no mismatch" for an empty table, so with no tunnel the rule applies on every interface, exactly as it did before. A stale entry would be equally harmless — an address no interface owns matches no packet.

Verified on an installed build across connect, disconnect and reconnect. The table follows the tunnel (`10.43.238.92` → empty → `10.7.178.49` on a reconnect that changed the address), both rules keep their `group` clause, and the anchor is never empty while `allowPIA` is true.

## Alternative fix

The more obvious approach is to exclude the tunnel by *interface* rather than by source address:

```diff
 # Allow traffic by privileged group (used by daemon)
-pass out proto { tcp, udp } group {{BRAND_CODE}}vpn flags any no state
+pass out on ! $interface proto { tcp, udp } group {{BRAND_CODE}}vpn flags any no state
```

```diff
-    _pFilter->setFilterEnabled("400.allowPIA", params.allowPIA);
+    const std::string allowPIAExcludedInterface = params.tunnelDeviceName.empty()
+        ? std::string{"lo0"} : params.tunnelDeviceName;
+    const bool allowPIAInterfaceChanged =
+        _allowPIAInterface != allowPIAExcludedInterface;
+    _allowPIAInterface = allowPIAExcludedInterface;
+    _pFilter->setFilterEnabled("400.allowPIA", params.allowPIA,
+        { {"interface", allowPIAExcludedInterface} },
+        allowPIAInterfaceChanged);
```

This works, and is in fact slightly more complete than the proposed fix — but it needs reload infrastructure threaded through three more files (`mac_firewall.h`, `pf_firewall.h`, `pf_firewall.cpp`).

The reason is that `PFFirewall::enableAnchor` substitutes macros **only while the anchor is empty**:

```sh
if pfctl -q -a 'ROOT/ANCHOR' -s rules | grep -q . ; then
    echo 'ANCHOR: ON'        # already has rules -> do nothing
else
    pfctl -q -a ... -F all <MACROS> -f '....conf'
fi
```

That is fine for every existing caller, but not for this one. `allowPIA` is `(blockAll || blockIPv6 || blockDNS)`, which is already true while disconnected, so the anchor is first loaded before any tunnel exists and the later call carrying the real device is a no-op. The rule would keep `on ! lo0` for the whole session and the fix would do nothing.

`$interface` can also legitimately be **empty**, and `on ! ` does not parse.

The table-based fix avoids all of this because the write-once behaviour applies to *macros* only: `setAnchorTable()` runs `pfctl -T replace` unconditionally on every update, so the value tracks the tunnel with no reload and no new plumbing.

NOTE: One caveat in the other direction, stated for completeness: `FirewallParams` carries only `tunnelDeviceLocalAddress` with no IPv6 counterpart, so IPv6 tunnel egress would still reach the group clause under the proposed fix, whereas `on ! <tunnel>` covers it unconditionally. Since IPv6 is blocked rather than tunnelled and there is no IPv6 tunnel address, that set should be empty in practice.

### Rejected alternative: `on ! utun` as an interface group

It parses, and fails **silently**. XNU has no pf interface-group support.

## Appendix — how packets triggered the deadlock

A pf rule carrying a `user`/`group` clause makes the kernel call `pf_socket_lookup()` for the packet under evaluation, to find the socket that owns it. That takes the global TCP PCB-info lock, `tcbinfo.ipi_lock`.

`400.allowPIA` constrained nothing (no interface, address or port) and the ruleset is `no state` throughout with no `quick` on any anchor that a non-loopback packet reaches, so evaluation always ran the full chain down to it, for **every outbound TCP/UDP packet on the machine**, not merely the first packet of each flow. pf evaluates a rule's tests in a fixed order (interface, direction, address family, protocol, addresses, ports, then uid/gid), so any earlier constraint that fails skips the lookup entirely — which is what both fixes above exploit.

On the tunnel output path that lookup runs with a socket lock already held:

```
dlil_input_utun4       holds per-socket mutex, waits ipi_lock SHARED
  dlil_input_thread_func -> proto_input -> ip_input -> tcp_input
  -> tcp_respond -> ip_output_list -> pf_af_hook -> pf_test -> pf_test_rule
  -> pf_socket_lookup -> in_pcblookup_hash -> lck_rw_lock_shared   BLOCKS

thread call kernel #2  holds ipi_lock EXCLUSIVE, waits the socket mutex
  thread_call_thread -> thread_call_delayed_timer -> inpcb_timeout
  -> tcp_garbage_collect -> in_pcbdispose -> sofreelastref
  -> tcp_lock -> lck_mtx_lock                                      BLOCKS
```

The two orders are opposite, so the threads wait on each other forever. Both end `TH_UNINT`, so neither is killable. The tunnel's DLIL input thread also holds a mutex that essentially every networking thread needs — 21+ threads piled up behind it in the captured stackshot, including `dlil_input_en7`, the *physical* NIC input thread — which is why all networking dies rather than just the tunnel, and why the machine wedges completely as system daemons block.

**The lock inversion is Apple's defect, not a client bug**, but it's difficult to get the report to Apple, and we cannot count on a timely response*. It is not novel either: FreeBSD hit the identical hazard with pf `user`/`group` rules once its network stack became fine-grained locked, documented it in the [5.3 errata](https://www.freebsd.org/releases/5.3R/errata/) and in `pf.conf(5)`, and in 2004 [added a `struct inpcb *` argument to pfil(9)](https://github.com/freebsd/freebsd-src/commit/d6a8d588758b384d3fbf57425b886754c9ed710d) specifically to work around it.

This PR does not depend on Apple fixing anything. It removes the client from the cycle, and independently drops a PCB hash lookup that every macOS user of the client currently pays on every outbound packet.

*I'm happy to provide a full report if anyone reading this wants it.

---

**Bureaucracy**

* [x] I have described below how to test my code and included unit tests where possible.
* [x] I have cleaned up the code and made best efforts to match the surrounding coding style.
* [x] I certify that I have the right to submit this contribution under the GPLv3 and alter as outlined in the Contributor License Agreement.